### PR TITLE
card border radius updated

### DIFF
--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -50,8 +50,8 @@ export function theme(): DefaultTheme {
 
 		radius: {
 			sm: "8px",
-			md: "12px",
-			lg: "16px",
+			md: "20px",
+			lg: "24px",
 			xl: "32px",
 		},
 


### PR DESCRIPTION
Currently border radius is 16px on project cards. Updated this to:

- 24px on desktop
- 20px on mobile